### PR TITLE
add libasound2-dev to ubuntu dependencies

### DIFF
--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -1,11 +1,11 @@
 FROM ubuntu:20.04
 RUN apt update -y
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
-RUN DEBIAN_FRONTEND=noninteractive apt install -y git cmake g++ qtbase5-dev qtmultimedia5-dev
+RUN DEBIAN_FRONTEND=noninteractive apt install -y git cmake g++ qtbase5-dev qtmultimedia5-dev libasound2-dev
 RUN git clone https://github.com/pjsip/pjproject.git /pjproject
 RUN cd /pjproject && \
 git checkout 2.10 && \
-./configure --prefix=/usr/lib --enable-static --disable-sound --disable-resample --disable-video --disable-opencore-amr && \
+./configure --prefix=/usr/lib --enable-static --disable-resample --disable-video --disable-opencore-amr && \
 make dep && \
 make && \
 make install && ldconfig

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You need `Qt5`, `CMake 2.8.11` or higher and `pjproject 2.10` before anything el
 For example, on Ubuntu:
 
 ```
-sudo apt install -y git cmake g++ qtbase5-dev qtmultimedia5-dev
+sudo apt install -y git cmake g++ qtbase5-dev qtmultimedia5-dev libasound2-dev
 ```
 
 Inspect `Dockerfile.*` files for other instructions if you want.


### PR DESCRIPTION
I had to install the libasound2-dev to avoid the bellow error.

```bash
21:21:34.650            pjsua_aud.c  .....Error retrieving default audio device parameters: Unable to find default audio device (PJMEDIA_EAUD_NODEFDEV) [status=420006]
21:21:34.650            pjsua_aud.c  ....Error opening sound device: Unable to find default audio device (PJMEDIA_EAUD_NODEFDEV) [status=420006]
21:21:34.650              media.cpp  ...pjsua_conf_connect(id, sink.id) error: Unable to find default audio device (PJMEDIA_EAUD_NODEFDEV) (status=420006) [../src/pjsua2/media.cpp:218]
```