### PR TITLE
refactor DTMF interface and check if the digit is valid

### DIFF
--- a/qss/style.qss
+++ b/qss/style.qss
@@ -1,0 +1,11 @@
+QDialog#call > QLineEdit#dtmfInput {
+    font-size: 8pt;
+    background: transparent;
+    color: black;
+    opacity: 100
+}
+
+QDialog#call > QLabel#whoLabel {
+    font-size: 8pt;
+    color: black;
+}

--- a/resources.qrc
+++ b/resources.qrc
@@ -2,4 +2,7 @@
   <qresource prefix="logo">
     <file>data/ktelephone.png</file>
   </qresource>
+  <qresource prefix="/">
+    <file>qss/style.qss</file>
+  </qresource>
 </RCC>

--- a/src/gui/ktelephonecall.cpp
+++ b/src/gui/ktelephonecall.cpp
@@ -4,6 +4,13 @@
 
 #include "ui_call.h"
 #include <QDebug>
+#include <QRegularExpression>
+
+bool isDTMFDigit(QString digit) {
+    QRegularExpression re("[0-9a-dA-D*#]");
+    QRegularExpressionMatch match = re.match(digit);
+    return match.hasMatch();
+}
 
 KTelephoneCall::KTelephoneCall(KTelephone *parent, QString direction, QString username) :
         QDialog(),
@@ -40,9 +47,6 @@ KTelephoneCall::KTelephoneCall(KTelephone *parent, QString direction, QString us
     connect(ui->transferButton,
             SIGNAL(clicked()), this,
             SLOT(openTransferCallDialog()));
-    connect(ui->dtmfInput,
-            SIGNAL(textEdited(QString)), this,
-            SLOT(actionDtmf(QString)));
 
     connect(this,
             SIGNAL(rejected()), this,
@@ -51,7 +55,9 @@ KTelephoneCall::KTelephoneCall(KTelephone *parent, QString direction, QString us
     ui->dtmfInput->hide();
     ui->dtmfInput->hide();
     ui->callAction->hide();
-
+    ui->dtmfInput->setReadOnly(true);
+    ui->dtmfInput->setEnabled(false);
+    ui->dtmfInput->setFrame(false);
     if (callDirection == "outbound") {
         ui->answerButton->deleteLater();
     }
@@ -95,6 +101,12 @@ void KTelephoneCall::callDestroy() {
 
 void KTelephoneCall::closeEvent(QCloseEvent* event) {
     this->onWindowClose();
+}
+
+void KTelephoneCall::keyPressEvent(QKeyEvent *event) {
+    if (isDTMFDigit(event->text())) {
+        this->actionDtmf(event->text());
+    }
 }
 
 void KTelephoneCall::onWindowClose() {
@@ -157,14 +169,15 @@ void KTelephoneCall::actionMute() {
     this->mute = !this->mute;
 }
 
-void KTelephoneCall::actionDtmf(QString text) {
-    if (!this->answered
-        || this->previousDtmf.length() >= text.length()) {
-        this->previousDtmf = text;
-        return;
+void KTelephoneCall::actionDtmf(QString digit) {
+    if (this->answered) {
+        try {
+            this->mCall->doDtmf(digit);
+            ui->dtmfInput->insert(digit);
+        } catch (Error &err) {
+            qDebug() << "DTMF Error " << QString::fromStdString(err.reason);
+        }
     }
-    this->mCall->doDtmf(text.right(1));
-    this->previousDtmf = text;
 }
 
 void KTelephoneCall::actionTransfer(QString destinationNumber) {

--- a/src/gui/ktelephonecall.cpp
+++ b/src/gui/ktelephonecall.cpp
@@ -4,13 +4,6 @@
 
 #include "ui_call.h"
 #include <QDebug>
-#include <QRegularExpression>
-
-bool isDTMFDigit(QString digit) {
-    QRegularExpression re("[0-9a-dA-D*#]");
-    QRegularExpressionMatch match = re.match(digit);
-    return match.hasMatch();
-}
 
 KTelephoneCall::KTelephoneCall(KTelephone *parent, QString direction, QString username) :
         QDialog(),
@@ -104,9 +97,7 @@ void KTelephoneCall::closeEvent(QCloseEvent* event) {
 }
 
 void KTelephoneCall::keyPressEvent(QKeyEvent *event) {
-    if (isDTMFDigit(event->text())) {
-        this->actionDtmf(event->text());
-    }
+    this->actionDtmf(event->text());
 }
 
 void KTelephoneCall::onWindowClose() {

--- a/src/gui/ktelephonecall.hpp
+++ b/src/gui/ktelephonecall.hpp
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QSound>
 #include <QShortcut>
+#include <QKeyEvent>
 
 class MyCall;
 
@@ -39,11 +40,12 @@ private:
     bool answered = false;
     bool hold = false;
     bool mute = false;
-    QString previousDtmf;
     KTelphoneTransferCall *transferCall = NULL;
 
 protected:
     void closeEvent(QCloseEvent*);
+
+    void keyPressEvent(QKeyEvent*);
 
 public slots:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,18 @@
 #include "ktelephone.hpp"
 #include "ktelephonemanager.hpp"
 
+QString readStyleSheet(QString path) {
+    QFile file(path);
+    file.open(QFile::ReadOnly);
+    return QString(file.readAll());
+}
+
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
-    const auto appIcon = QIcon("data/ktelephone.png");
+    QIcon appIcon("data/ktelephone.png");
     app.setWindowIcon(appIcon);
+    app.setStyleSheet(readStyleSheet(":/qss/style.qss"));
+
     KTelephoneManager m;
     return app.exec();
 }

--- a/src/ui/call.ui
+++ b/src/ui/call.ui
@@ -45,13 +45,6 @@
                     </item>
                 </layout>
             </item>
-            <item row="2" column="0">
-                <widget class="QLabel" name="descLabel">
-                    <property name="text">
-                        <string/>
-                    </property>
-                </widget>
-            </item>
             <item row="3" column="0">
                 <widget class="QLineEdit" name="dtmfInput"/>
             </item>


### PR DESCRIPTION
This PR is changing the user interface to send DTMF digits, instead of using an "input" the application captures all keyboard events of the call dialog and sends the text if is a valid DTMF, this behavior is similar to  [Telephone](https://apps.apple.com/br/app/telephone/id406825478?mt=12).

![ktelephone_dtmf](https://user-images.githubusercontent.com/3819494/150238089-584c9cb0-b786-45b1-bb88-e41b7c2f540b.gif)
